### PR TITLE
car/hyundai: tighten EV9 parking mode gating

### DIFF
--- a/opendbc/car/hyundai/README.md
+++ b/opendbc/car/hyundai/README.md
@@ -48,3 +48,14 @@ Due to its physics characteristics, the Santa Fe requires smaller steering angle
 Due to different physical characteristics, the Ioniq 5 PE can handle larger steering angles while still remaining within the same ISO safety standards.
 
 By using the Santa Fe's conservative limits across all vehicles, we ensure the Ioniq 5 PE operates well within its capabilities, while preventing the Santa Fe from exceeding its safety thresholds.
+
+## Kia EV9 Angle-Steering Integration
+
+This angle-steering development branch extends the Hyundai/Kia/Genesis stack to explicitly support the Kia EV9 platform:
+
+- **Platform identification:** The Hyundai values module now encodes a three-bit CAN-FD platform identifier and exposes the `HyundaiCanfdPlatform` enum so that the EV9 can be tagged at the CarParams layer and in safety tests.【F:opendbc/car/hyundai/values.py†L126-L134】【F:opendbc/safety/tests/test_hyundai_canfd.py†L8-L15】 The Hyundai interface applies this identifier to EV9 angle-steering configurations so Panda can select the correct vehicle model.【F:opendbc/car/hyundai/interface.py†L161-L164】
+- **Panda safety vehicle model:** The CAN-FD safety hooks cache the platform identifier, define EV9-specific vehicle-model parameters, and choose them when validating steering angle commands; initialization decodes the ID directly from `safetyParam`.【F:opendbc/safety/modes/hyundai_canfd.h†L48-L52】【F:opendbc/safety/modes/hyundai_canfd.h†L195-L227】【F:opendbc/safety/modes/hyundai_canfd.h†L343-L351】
+- **Controller alignment:** The Hyundai angle controller now inspects the Panda platform ID and skips the legacy baseline fallback when Panda has already switched to an EV9 vehicle model, keeping both sides aligned on the same physics assumptions.【F:opendbc/car/hyundai/carcontroller.py†L214-L225】
+- **Safety coverage:** Dedicated EV9 safety tests exercise the Panda EV9 vehicle model to verify the lateral acceleration and jerk checks with the EV9 limits.【F:opendbc/safety/tests/test_hyundai_canfd.py†L514-L579】
+- **Supporting data:** The EV9 platform definition advertises CAN-FD angle-steering support, torque overrides align with other HKG angle platforms, and the replay guide includes EV9 environment variables for debugging this branch.【F:opendbc/car/hyundai/values.py†L622-L627】【F:opendbc/car/torque_data/override.toml†L100-L105】【F:opendbc/car/hyundai/tests/replay_route.md†L11-L16】
+- **Low-speed parking mode assist:** The EV9 angle controller now only enters ADAS parking mode between 1–7 km/h when the steering request exceeds 120°, clamps commands to the 176.7° MDPS cap, forces an exit once speeds drop below 0.5 km/h, exceed 10 km/h, or after roughly 0.8 s, and enforces a 0.5 s cooldown before re-enabling while sending the matching LKAS parking frame to honor the sharper rack limit without touching higher-speed behavior.【F:opendbc/car/hyundai/carcontroller.py†L215-L290】【F:opendbc/car/hyundai/hyundaicanfd.py†L39-L78】【F:opendbc/car/hyundai/values.py†L69-L77】

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -41,6 +41,9 @@ MAX_ANGLE_CONSECUTIVE_FRAMES = 2
 MAX_ANGLE_RATE = 5
 ANGLE_SAFETY_BASELINE_MODEL = "HYUNDAI_SANTA_FE_HEV_5TH_GEN"
 
+# Parallel parking mode is only enabled on the EV9 for very low-speed, large-angle maneuvers.
+PARKING_MODE_CANDIDATE = CAR.KIA_EV9
+
 
 def get_baseline_safety_cp():
   from opendbc.car.hyundai.interface import CarInterface
@@ -160,6 +163,13 @@ class CarController(CarControllerBase, EsccCarController, LeadDataCarController,
     # For future parametrization / tuning
     self.angle_enable_smoothing_factor = True
 
+    # Parking mode state for EV9 low-speed sharp turns
+    self.ev9_parallel_parking_mode = False
+    self.ev9_parking_mode_start_frame = None
+    self.ev9_parking_mode_reenable_frame = 0
+    self._parking_mode_max_frames = max(1, math.ceil(CarControllerParams.PARKING_MODE_MAX_DURATION / DT_CTRL))
+    self._parking_mode_reenable_frames = max(0, math.ceil(CarControllerParams.PARKING_MODE_REENGAGE_DELAY / DT_CTRL))
+
     self._params = Params() if PARAMS_AVAILABLE else None
     if PARAMS_AVAILABLE:
       self.params.ANGLE_MIN_TORQUE_REDUCTION_GAIN = parse_tq_rdc_gain(
@@ -206,10 +216,49 @@ class CarController(CarControllerBase, EsccCarController, LeadDataCarController,
       v_ego_raw = CS.out.vEgoRaw
       desired_angle = np.clip(actuators.steeringAngleDeg, -self.params.ANGLE_LIMITS.STEER_ANGLE_MAX, self.params.ANGLE_LIMITS.STEER_ANGLE_MAX)
 
+      if self.CP.carFingerprint == PARKING_MODE_CANDIDATE:
+        requested_angle = abs(actuators.steeringAngleDeg)
+        speed = abs(v_ego_raw)
+
+        if self.ev9_parallel_parking_mode:
+          elapsed_frames = 0
+          if self.ev9_parking_mode_start_frame is not None:
+            elapsed_frames = self.frame - self.ev9_parking_mode_start_frame
+
+          timed_out = elapsed_frames >= self._parking_mode_max_frames
+          if (not CC.latActive or speed > CarControllerParams.PARKING_MODE_EXIT_SPEED_MAX or
+              speed < CarControllerParams.PARKING_MODE_EXIT_SPEED_MIN or
+              requested_angle < CarControllerParams.PARKING_MODE_EXIT_ANGLE_DEG or timed_out):
+            self.ev9_parallel_parking_mode = False
+            self.ev9_parking_mode_start_frame = None
+            if self._parking_mode_reenable_frames:
+              self.ev9_parking_mode_reenable_frame = self.frame + self._parking_mode_reenable_frames
+        else:
+          reenable_ready = self.frame >= self.ev9_parking_mode_reenable_frame
+          if (CC.latActive and reenable_ready and
+              CarControllerParams.PARKING_MODE_ENTRY_SPEED_MIN <= speed <= CarControllerParams.PARKING_MODE_ENTRY_SPEED_MAX and
+              requested_angle >= CarControllerParams.PARKING_MODE_ENTRY_ANGLE_DEG):
+            self.ev9_parallel_parking_mode = True
+            self.ev9_parking_mode_start_frame = self.frame
+      else:
+        if self.ev9_parallel_parking_mode:
+          self.ev9_parking_mode_start_frame = None
+        self.ev9_parallel_parking_mode = False
+
+      if self.ev9_parallel_parking_mode:
+        desired_angle = float(np.clip(desired_angle,
+                                      -CarControllerParams.PARKING_MODE_MAX_ANGLE_DEG,
+                                      CarControllerParams.PARKING_MODE_MAX_ANGLE_DEG))
+
       if self.angle_enable_smoothing_factor and abs(v_ego_raw) < CarControllerParams.SMOOTHING_ANGLE_MAX_VEGO:
         desired_angle = sp_smooth_angle(v_ego_raw, desired_angle, self.apply_angle_last)
 
       apply_angle = apply_steer_angle_limits_vm(desired_angle, self.apply_angle_last, v_ego_raw, CS.out.steeringAngleDeg, CC.latActive, self.params, self.VM)
+
+      if self.ev9_parallel_parking_mode and apply_angle is not None:
+        apply_angle = float(np.clip(apply_angle,
+                                    -CarControllerParams.PARKING_MODE_MAX_ANGLE_DEG,
+                                    CarControllerParams.PARKING_MODE_MAX_ANGLE_DEG))
 
       # Historically we applied the baseline Santa Fe model on top to match Panda's hardcoded baseline.
       # Now, when Panda encodes a platform ID (e.g., EV9), it uses a platform-specific VM. In that case, skip the fallback.
@@ -242,6 +291,10 @@ class CarController(CarControllerBase, EsccCarController, LeadDataCarController,
         apply_torque = 0
         apply_angle = CS.out.steeringAngleDeg
         apply_steer_req = False
+        self.ev9_parallel_parking_mode = False
+        self.ev9_parking_mode_start_frame = None
+        if self._parking_mode_reenable_frames:
+          self.ev9_parking_mode_reenable_frame = self.frame + self._parking_mode_reenable_frames
 
       # After we've used the last angle wherever we needed it, we now update it.
       self.apply_angle_last = apply_angle
@@ -280,7 +333,7 @@ class CarController(CarControllerBase, EsccCarController, LeadDataCarController,
     # *** CAN/CAN FD specific ***
     if self.CP.flags & HyundaiFlags.CANFD:
       can_sends.extend(self.create_canfd_msgs(apply_steer_req, apply_torque, set_speed_in_units, accel,
-                                              stopping, hud_control, CS, CC))
+                                              stopping, hud_control, CS, CC, self.ev9_parallel_parking_mode))
     else:
       can_sends.extend(self.create_can_msgs(apply_steer_req, apply_torque, torque_fault, set_speed_in_units, accel,
                                             stopping, hud_control, actuators, CS, CC))
@@ -342,15 +395,16 @@ class CarController(CarControllerBase, EsccCarController, LeadDataCarController,
 
     return can_sends
 
-  def create_canfd_msgs(self, apply_steer_req, apply_torque, set_speed_in_units, accel, stopping, hud_control, CS, CC):
+  def create_canfd_msgs(self, apply_steer_req, apply_torque, set_speed_in_units, accel, stopping, hud_control, CS, CC, parking_mode_active):
     can_sends = []
 
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
     lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
 
     # steering control
-    can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque, self.apply_angle_last
-                                                           , self.lkas_icon))
+    can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req,
+                                                           apply_torque, self.apply_angle_last, self.lkas_icon,
+                                                           parking_mode_active))
 
     # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
     if self.frame % 5 == 0 and lka_steering:

--- a/opendbc/car/hyundai/hyundaicanfd.py
+++ b/opendbc/car/hyundai/hyundaicanfd.py
@@ -36,7 +36,7 @@ class CanBus(CanBusBase):
     return self._cam
 
 
-def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_torque, apply_angle, lkas_icon):
+def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_torque, apply_angle, lkas_icon, parking_mode_active):
   values = {
     "LKA_OptUsmSta": 2,
     "LKA_SysIndReq": 2 if enabled else 1,
@@ -61,6 +61,10 @@ def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_torque,
       "ADAS_ACIAnglTqRedcGainVal": apply_torque if lat_active else 0,
     }
 
+    if parking_mode_active:
+      values["ADAS_ActvACISta"] = 2
+      values["ADAS_ActvACILvl2Sta"] = 2
+
   ret = []
   if CP.flags & HyundaiFlags.CANFD_LKA_STEERING:
     lkas_msg = "LKAS_ALT" if CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT else "LKAS"
@@ -69,6 +73,8 @@ def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_torque,
     ret.append(packer.make_can_msg(lkas_msg, CAN.ACAN, values))
   else:
     ret.append(packer.make_can_msg("LFA", CAN.ECAN, values))
+    if parking_mode_active and CP.flags & HyundaiFlags.CANFD_ANGLE_STEERING:
+      ret.append(packer.make_can_msg("LKAS_ALT", CAN.ECAN, values))
 
   return ret
 

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -66,6 +66,17 @@ class CarControllerParams:
   SMOOTHING_ANGLE_ALPHA_MATRIX = [0.05, 0.1, 0.3, 0.6, 1]
   SMOOTHING_ANGLE_MAX_VEGO = SMOOTHING_ANGLE_VEGO_MATRIX[-1]
 
+  # EV9 parallel parking mode thresholds (m/s, seconds, and degrees)
+  PARKING_MODE_ENTRY_SPEED_MIN = 1.0 * CV.KPH_TO_MS  # avoids commanding parking mode from a stop
+  PARKING_MODE_ENTRY_SPEED_MAX = 7.0 * CV.KPH_TO_MS  # ~7 km/h entry ceiling
+  PARKING_MODE_EXIT_SPEED_MIN = 0.5 * CV.KPH_TO_MS   # drop out if we slow back toward a stop
+  PARKING_MODE_EXIT_SPEED_MAX = 10.0 * CV.KPH_TO_MS  # ~10 km/h upper bound for hysteresis
+  PARKING_MODE_ENTRY_ANGLE_DEG = 120.0
+  PARKING_MODE_EXIT_ANGLE_DEG = 105.0
+  PARKING_MODE_MAX_ANGLE_DEG = 176.7
+  PARKING_MODE_MAX_DURATION = 0.8  # seconds of parking assist before releasing back to standard control
+  PARKING_MODE_REENGAGE_DELAY = 0.5  # seconds to wait before we may re-enable parking assist
+
   def __init__(self, CP):
     self.STEER_DELTA_UP = 3
     self.STEER_DELTA_DOWN = 7


### PR DESCRIPTION
## Summary
- tighten the EV9 parking-mode activation window to 1–7 km/h, cap individual assists at ~0.8 s, add a cooldown before re-enabling, and exit below 0.5 km/h or above 10 km/h while clipping to the MDPS limit
- document the updated EV9 parking-mode behavior in the Hyundai angle-steering README

## Testing
- pytest opendbc/car/hyundai/tests -q *(fails: ValueError: cannot hash writable memoryview object)*

------
https://chatgpt.com/codex/tasks/task_b_68d06fc8abbc832d885ecbf2401aa126